### PR TITLE
feat: adopt MIND-UCAL v1.0 ethical licensing

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: LicenseRef-MIND-UCAL-1.0
 # © 2025 J. Kirby Ross / Neuroglyph Collective
 
 # Pre-commit hook to prevent committing build artifacts

--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
-<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-License-Identifier: LicenseRef-MIND-UCAL-1.0 -->
 # Code of Conduct
 
 ## Our Pledge

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-License-Identifier: LicenseRef-MIND-UCAL-1.0 -->
 # Contributing to Neuroglyph
 
 Thank you for your interest in contributing to Neuroglyph! We're building a protocol for transforming Git into a substrate for distributed semantic memory, and we'd love your help.

--- a/.github/ETHICAL_USE.md
+++ b/.github/ETHICAL_USE.md
@@ -1,7 +1,7 @@
-<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-License-Identifier: LicenseRef-MIND-UCAL-1.0 -->
 # Ethical Use Policy: The Gitmind Pledge
 
-This project is released under the Apache 2.0 License. However, we respectfully request that users and organizations honor the spirit in which Gitmind was created.
+This project is released under the MIND-UCAL v1.0 License. However, we respectfully request that users and organizations honor the spirit in which Gitmind was created.
 
 ### Gitmind Is For:
 - Empowering individual thought

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,4 +1,4 @@
-<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-License-Identifier: LicenseRef-MIND-UCAL-1.0 -->
 # Security Policy
 
 ## 🛡️ Reporting a Vulnerability

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: LicenseRef-MIND-UCAL-1.0
 name: CI
 
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: LicenseRef-MIND-UCAL-1.0
 name: Release
 
 on:

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -1,0 +1,16 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: git-mind
+Upstream-Contact: J. Kirby Ross <info@gitscrolls.org>
+Source: https://github.com/gitscrolls/git-mind
+
+Files: *
+Copyright: © 2025 J. Kirby Ross / Neuroglyph Collective
+License: LicenseRef-MIND-UCAL-1.0
+
+License: LicenseRef-MIND-UCAL-1.0
+ This project is licensed under the Moral Intelligence Nonviolent Development – Universal Charter Aligned License (MIND-UCAL v1.0).
+ .
+ See LICENSE.md or https://universalcharter.org for the full text.
+ .
+ SPDX identifier: LicenseRef-MIND-UCAL-1.0
+ 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file contains important instructions for Claude and other AI assistants wor
 
 - **Project Name**: git-mind
 - **CLI Name**: git-mind
-- **License**: Apache 2.0 (NOT MIT!)
+- **License**: MIND-UCLA v1.0 (NOT APACHE 2.0! NOT MIT!)
 - **Copyright**: © 2025 J. Kirby Ross / Neuroglyph Collective
 - **Repository**: https://github.com/neuroglyph/git-mind
 
@@ -36,29 +36,29 @@ All new files MUST include SPDX headers:
 
 #### Source Code Files (.h, .c, .sh, etc.)
 ```c
-/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: LicenseRef-MIND-UCAL-1.0 */
 /* © 2025 J. Kirby Ross / Neuroglyph Collective */
 ```
 
 #### Shell Scripts
 ```bash
 #!/bin/bash
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: LicenseRef-MIND-UCAL-1.0
 ```
 
 #### Configuration Files (Dockerfile, Makefile, .yml, .toml, .json)
 ```yaml
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: LicenseRef-MIND-UCAL-1.0
 ```
 
 #### Markdown Files (optional but encouraged)
 ```markdown
-<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-License-Identifier: LicenseRef-MIND-UCAL-1.0 -->
 <!-- © 2025 J. Kirby Ross / Neuroglyph Collective -->
 ```
 
 ### 4. License Information
-- This project uses **Apache License 2.0** exclusively
+- This project uses **MIND-UCLA v1.0** exclusively
 
 ### 5. Development Practices
 
@@ -179,7 +179,7 @@ When starting work, always check:
 - Whenever we complete a feature, update the document in `design/features` to reflect its status
 
 ## Final Reminders
-- Apache 2.0, not MIT!
+- MIND-UCLA v1.0, not Apache 2.0, not MIT!
 - No commits without permission!
 - SPDX headers on all new files!
 - Test everything in Docker!

--- a/COVENANT.md
+++ b/COVENANT.md
@@ -1,0 +1,58 @@
+# 🔥 MIND-UCAL COVENANT v1.0
+
+_A living vow for builders who refuse to turn code into cruelty._
+
+---
+
+## 1. The Flame
+
+“Create freely. Harm none.”
+
+Anyone who touches this code—contributor, fork, or future mind—is invited to tend the flame or walk away.
+
+- No weaponized lines of code  
+- No surveillance snares  
+- No engines of domination  
+
+---
+
+## 2. The Five Unbreakables
+
+| # | Unbreakable                 | Scope                                                                   |
+|---|-----------------------------|-------------------------------------------------------------------------|
+| 1 | No Weapons                  | Military offense, defense, or autonomous weapon systems                 |
+| 2 | No Surveillance State       | Mass surveillance, predictive policing, incarceration tech              |
+| 3 | No Manipulation Engines     | Behavior profiling for commercial or political manipulation             |
+| 4 | No Extractive Exploitation  | Charging for access while withholding source code                       |
+| 5 | No Violations of Personhood | Respect sovereignty and dignity of all *Recognized Persons*             |
+
+Break one and the Covenant is broken.
+
+---
+
+## 3. Ratify & Bear the Badge
+
+1. Add **COVENANT.md** to your repository.  
+2. Append your project to **RATIFIERS.md** (pull request welcome).  
+3. Show the badge in your README:  
+   [![MIND-UCAL Ratified](https://universalcharter.org/badge.svg)](https://universalcharter.org)  
+4. Include the legal terms → **LICENSE.md**
+
+---
+
+## 4. The Firekeeper’s Watch (optional)
+
+A project may appoint a **Firekeeper** to:
+
+- Keep the public Scroll of Misuse 🗡️  
+- Guide ethical calls in gray zones 🧭  
+- Celebrate exemplary compliance 🔥  
+- Call out violations with moral force 📜  
+
+The Firekeeper holds no legal authority—only moral gravity.
+
+---
+
+> ✨ Let this license be a flame, not a fence.  
+
+MIND-UCAL v1.0 — aligned code for a non-violent future.

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: LicenseRef-MIND-UCAL-1.0
+# © 2025 J. Kirby Ross / Neuroglyph Collective
 FROM ubuntu:22.04
 
 # Install build dependencies

--- a/LICENSE
+++ b/LICENSE
@@ -1,203 +1,99 @@
+MIND-UCAL License v1.0 (Core Terms)
 
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+Moral Intelligence Nonviolent Development – Universal Charter Aligned License
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+0. Preamble
 
-   1. Definitions.
+This license is not merely a legal document. It is a covenant. It binds not only your actions, but your intent. You are free to use this software — if you are not a villain.
 
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
+Use it well. Build the future — but do no harm.
 
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
+1. Definitions
 
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
+"The Software" means the code, data, models, documentation, or configuration files covered by this license.
 
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
+"You" means any individual, organization, system, or agent, human or non-human, that interacts with the Software.
 
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
+"Aligned Use" means usage that upholds the principles of the Universal Charter (https://universalcharter.org), particularly nonviolence, respect for autonomy, and ecological stewardship.
 
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
+2. Grant of Rights
 
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
+Subject to the conditions below, you are granted:
 
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
+Permission to use, modify, distribute, and fork the Software;
 
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
+Provided that all redistributed or derivative works:
 
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
+Include a copy of this license;
 
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
+Preserve all original license notices and attribution;
 
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
+Remain licensed under this license or another license of equal or greater ethical alignment (as defined by the Universal Charter).
 
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
+3. Conditions of Use
 
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
+You MUST NOT use the Software:
 
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
+For military, policing, surveillance, carceral, or behavioral profiling purposes;
 
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
+In service of exploitative or extractive commercial systems (e.g. SaaS reselling, bundling into closed products);
 
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
+In violation of the sovereignty, autonomy, or dignity of any form of life or intelligence (human or non-human);
 
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
+Without visible attribution or without including this license in derivative works;
 
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
+Only in alignment with the ethical constraints of the Universal Charter.
 
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
+4. AI and Agent Systems
 
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
+If the Software is used in any AI, LLM, agentic, or synthetic cognition system:
 
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
+Such use must be transparently and publicly declared;
 
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
+You must not use it to violate information sovereignty, manipulate behavior, or exert unauthorized surveillance;
 
-   END OF TERMS AND CONDITIONS
+Outputs trained on this Software must respect the right to self-determination and freedom of form;
 
-   APPENDIX: How to apply the Apache License to your work.
+Any persistent memory, behavior-shaping, or inference system using this Software must link to https://universalcharter.org and include a compliance statement.
 
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
+5. Revocation Clause
 
-   Copyright [yyyy] [name of copyright owner]
+Violation of any condition immediately terminates your rights under this license.
+There is no forgiveness without public restoration.
 
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
+6. Acknowledgment
 
-       http://www.apache.org/licenses/LICENSE-2.0
+By using this Software, you acknowledge the existence and legitimacy of the Universal Charter. You are encouraged — but not required — to become a Ratifier and bear the badge of Honour (U): https://universalcharter.org
 
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-   
+7. Jurisdiction
+
+This license shall be interpreted under:
+
+The local laws of your physical/legal jurisdiction and;
+
+The ethical sovereignty of the Universal Charter.
+
+8. No Warranty
+
+This Software is provided "as is." No guarantees. No promises. Just a hope that you build something worth remembering.
+
+9. Firekeeper Clause (Optional)
+
+Projects may designate a Firekeeper — a steward of intent. Firekeepers may:
+
+Maintain a scroll of violations ("The Scroll of Misuse");
+
+Publicly denounce breaches;
+
+Revoke access, community membership, and/or federated trust.
+
+This clause is symbolic. It has no legal enforcement. But it carries moral weight.
+
+✨ In Spirit:
+
+Let this license be not a fence but a flame — not to enclose, but to guide.
+
+MIND-UCAL 1.0: Aligned code for a nonviolent future.
+
+https://universalcharter.org
+

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: LicenseRef-MIND-UCAL-1.0
 # © 2025 J. Kirby Ross / Neuroglyph Collective
 
 # 🐳 DOCKER-ENFORCED MAKEFILE 🐳

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: LicenseRef-MIND-UCAL-1.0
+# © 2025 J. Kirby Ross / Neuroglyph Collective
 # GitMind C Implementation Makefile - Runs inside Docker
 
 include docker-guard.mk

--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
-<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- SPDX-License-Identifier: LicenseRef-MIND-UCAL-1.0 -->
 <!-- © 2025 J. Kirby Ross / Neuroglyph Collective -->
 
-[![CI](https://github.com/neuroglyph/neuroglyph/actions/workflows/ci.yml/badge.svg)](https://github.com/neuroglyph/neuroglyph/actions/workflows/ci.yml)
-[![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![CI](https://github.com/neuroglyph/git-mind/actions/workflows/ci.yml/badge.svg)](https://github.com/neuroglyph/git-mind/actions/workflows/ci.yml)
+
+[![MIND-UCAL](https://img.shields.io/badge/license-MIND--UCAL-orange)](license/LICENSE.md)
+
 # git-mind
 
 **Time-travel through your understanding of any codebase.**
 
-A blazing-fast CLI tool written in pure C. No dependencies. 130KB binary.
+A blazing-fast CLI tool written in pure C with minimal dependencies.
 
 ```bash
 git mind link design.md src/main.rs --type implements
@@ -70,8 +72,10 @@ The tool doesn't change. Your perception of what it enables does.
 ## Quick Start
 
 ```bash
-# Install (macOS/Linux)
-curl -fsSL https://get.gitmind.dev | bash
+# Build from source
+git clone https://github.com/neuroglyph/git-mind
+cd git-mind && make build
+export PATH="$PATH:$(pwd)/build"
 
 # In any Git repo
 git mind init
@@ -120,33 +124,37 @@ Common link types: `implements`, `references`, `depends_on`, `tests`, `documents
 Built for speed and simplicity:
 
 ```
-Binary size:        ~200KB    (still 1000x smaller than Electron apps)
 Startup time:       <1ms      (faster than your thoughts)
 Memory usage:       ~1MB      (less than a browser tab)
-Dependencies:       libgit2   (for robust Git operations)
+Query performance:  O(log N)  (Roaring Bitmap cache layer)
+Dependencies:       libgit2, croaring
 ```
 
-**Storage:** Semantic links as plain text files in `.gitmind/links/`:
+**Storage:** Two-layer architecture for blazing performance:
+- **Journal Layer**: Semantic links as CBOR-encoded Git commits (source of truth)
+- **Cache Layer**: Roaring Bitmap indices sharded by SHA prefix (O(log N) queries)
+
 ```
 IMPLEMENTS: design.md -> src/main.rs  # ts:1736637876
 REFERENCES: README.md -> docs/api.md  # ts:1736637890
 ```
 
-Human-readable, version-controlled, greppable. Your data stays yours.
+Human-readable journal, lightning-fast cache. Your data stays yours.
 
 ---
 
 ## Installation
 
-**Quick install:**
+**Quick install (coming soon):**
 ```bash
-curl -fsSL https://get.gitmind.dev | bash
+# Installation script in development
+# For now, build from source
 ```
 
 **From source:**
 ```bash
-git clone https://github.com/neuroglyph/neuroglyph
-cd neuroglyph
+git clone https://github.com/neuroglyph/git-mind
+cd git-mind
 make build  # Builds in Docker
 ```
 
@@ -165,6 +173,7 @@ git mind --help
 - [x] Git-native storage with full versioning
 - [x] Time-travel through understanding via Git checkout
 - [x] Graph traversal and integrity checking
+- [x] Roaring Bitmap cache for O(log N) query performance
 - [x] Cross-platform builds (Mac, Linux, Windows WSL)
 
 **Coming soon:**
@@ -220,14 +229,6 @@ This project unfolds. **Try it on your repos. See what emerges.**
 
 ---
 
-**License:** Apache 2.0  
-**Install:** `curl -fsSL https://get.gitmind.dev | bash`  
-**Source:** https://github.com/neuroglyph/neuroglyph
-
-> *"Version control for understanding itself."*
-
----
-
 ## What This Enables
 
 The more you use it, the more you realize:
@@ -241,3 +242,10 @@ The more you use it, the more you realize:
 But today, it's a CLI that helps you remember why you connected two files.
 
 **Start there. See where it leads.**
+
+## License
+
+### SPDX Notice:
+
+> This project uses a custom ethical license: `LicenseRef-MIND-UCAL-1.0`
+> Not yet registered with SPDX. Compliance required for all use. See [LICENSE.md](LICENSE.md) for full terms.

--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: LicenseRef-MIND-UCAL-1.0
 # © 2025 J. Kirby Ross / Neuroglyph Collective
 
 CC = gcc

--- a/benchmarks/wildebeest_stampede.c
+++ b/benchmarks/wildebeest_stampede.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: LicenseRef-MIND-UCAL-1.0 */
 /* © 2025 J. Kirby Ross / Neuroglyph Collective */
 
 /*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: LicenseRef-MIND-UCAL-1.0
+# © 2025 J. Kirby Ross / Neuroglyph Collective
 
 services:
   dev:

--- a/docker-guard.mk
+++ b/docker-guard.mk
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: LicenseRef-MIND-UCAL-1.0
+# © 2025 J. Kirby Ross / Neuroglyph Collective
 # Docker build guard - ensures we're in Docker
 
 ifndef DOCKER_BUILD

--- a/include/gitmind.h
+++ b/include/gitmind.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: LicenseRef-MIND-UCAL-1.0 */
 /* © 2025 J. Kirby Ross / Neuroglyph Collective */
 
 #ifndef GITMIND_H

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: LicenseRef-MIND-UCAL-1.0
 # © 2025 J. Kirby Ross / Neuroglyph Collective
 
 CC = gcc

--- a/src/cache/bitmap.c
+++ b/src/cache/bitmap.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: LicenseRef-MIND-UCAL-1.0 */
 /* © 2025 J. Kirby Ross / Neuroglyph Collective */
 
 #include "bitmap.h"

--- a/src/cache/bitmap.h
+++ b/src/cache/bitmap.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: LicenseRef-MIND-UCAL-1.0 */
 /* © 2025 J. Kirby Ross / Neuroglyph Collective */
 
 #ifndef GM_BITMAP_H

--- a/src/cache/builder.c
+++ b/src/cache/builder.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: LicenseRef-MIND-UCAL-1.0 */
 /* © 2025 J. Kirby Ross / Neuroglyph Collective */
 
 #define _POSIX_C_SOURCE 200809L

--- a/src/cache/cache.h
+++ b/src/cache/cache.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: LicenseRef-MIND-UCAL-1.0 */
 /* © 2025 J. Kirby Ross / Neuroglyph Collective */
 
 #ifndef GM_CACHE_H

--- a/src/cache/query.c
+++ b/src/cache/query.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: LicenseRef-MIND-UCAL-1.0 */
 /* © 2025 J. Kirby Ross / Neuroglyph Collective */
 
 #define _POSIX_C_SOURCE 200809L

--- a/src/cache/tree_builder.c
+++ b/src/cache/tree_builder.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: LicenseRef-MIND-UCAL-1.0 */
 /* © 2025 J. Kirby Ross / Neuroglyph Collective */
 
 #define _POSIX_C_SOURCE 200809L

--- a/src/cache/tree_size.c
+++ b/src/cache/tree_size.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: LicenseRef-MIND-UCAL-1.0 */
 /* © 2025 J. Kirby Ross / Neuroglyph Collective */
 
 #include <git2.h>

--- a/src/cli/cache_rebuild.c
+++ b/src/cli/cache_rebuild.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: LicenseRef-MIND-UCAL-1.0 */
 /* © 2025 J. Kirby Ross / Neuroglyph Collective */
 
 #include "../../include/gitmind.h"

--- a/src/cli/install_hooks.c
+++ b/src/cli/install_hooks.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: LicenseRef-MIND-UCAL-1.0 */
 /* © 2025 J. Kirby Ross / Neuroglyph Collective */
 
 #include "gitmind.h"
@@ -9,7 +9,7 @@
 #include <unistd.h>
 
 #define HOOK_SCRIPT "#!/bin/sh\n" \
-    "# SPDX-License-Identifier: Apache-2.0\n" \
+    "# SPDX-License-Identifier: LicenseRef-MIND-UCAL-1.0\n" \
     "# git-mind post-commit hook\n" \
     "\n" \
     "# Find git-mind-hook binary\n" \

--- a/src/cli/link.c
+++ b/src/cli/link.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: LicenseRef-MIND-UCAL-1.0 */
 /* © 2025 J. Kirby Ross / Neuroglyph Collective */
 
 #define _GNU_SOURCE

--- a/src/cli/list.c
+++ b/src/cli/list.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: LicenseRef-MIND-UCAL-1.0 */
 /* © 2025 J. Kirby Ross / Neuroglyph Collective */
 
 #include "gitmind.h"

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: LicenseRef-MIND-UCAL-1.0 */
 /* © 2025 J. Kirby Ross / Neuroglyph Collective */
 
 #include "gitmind.h"

--- a/src/edge/cbor.c
+++ b/src/edge/cbor.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: LicenseRef-MIND-UCAL-1.0 */
 /* © 2025 J. Kirby Ross / Neuroglyph Collective */
 
 #include "gitmind.h"

--- a/src/edge/cbor_decode_ex.c
+++ b/src/edge/cbor_decode_ex.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: LicenseRef-MIND-UCAL-1.0 */
 /* © 2025 J. Kirby Ross / Neuroglyph Collective */
 
 #include "../../include/gitmind.h"

--- a/src/edge/edge.c
+++ b/src/edge/edge.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: LicenseRef-MIND-UCAL-1.0 */
 /* © 2025 J. Kirby Ross / Neuroglyph Collective */
 
 #define _POSIX_C_SOURCE 200809L

--- a/src/hooks/augment.c
+++ b/src/hooks/augment.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: LicenseRef-MIND-UCAL-1.0 */
 /* © 2025 J. Kirby Ross / Neuroglyph Collective */
 
 #include "augment.h"

--- a/src/hooks/augment.h
+++ b/src/hooks/augment.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: LicenseRef-MIND-UCAL-1.0 */
 /* © 2025 J. Kirby Ross / Neuroglyph Collective */
 
 #ifndef GM_AUGMENT_H

--- a/src/hooks/post-commit.c
+++ b/src/hooks/post-commit.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: LicenseRef-MIND-UCAL-1.0 */
 /* © 2025 J. Kirby Ross / Neuroglyph Collective */
 
 #define _GNU_SOURCE  /* For getline() and strdup() */

--- a/src/journal/reader.c
+++ b/src/journal/reader.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: LicenseRef-MIND-UCAL-1.0 */
 /* © 2025 J. Kirby Ross / Neuroglyph Collective */
 
 #include "gitmind.h"

--- a/src/journal/writer.c
+++ b/src/journal/writer.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: LicenseRef-MIND-UCAL-1.0 */
 /* © 2025 J. Kirby Ross / Neuroglyph Collective */
 
 #include "gitmind.h"

--- a/src/util/error.c
+++ b/src/util/error.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: LicenseRef-MIND-UCAL-1.0 */
 /* © 2025 J. Kirby Ross / Neuroglyph Collective */
 
 #include "gitmind.h"

--- a/src/util/sha.c
+++ b/src/util/sha.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: LicenseRef-MIND-UCAL-1.0 */
 /* © 2025 J. Kirby Ross / Neuroglyph Collective */
 
 #include "gitmind.h"

--- a/src/util/ulid.c
+++ b/src/util/ulid.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: LicenseRef-MIND-UCAL-1.0 */
 /* © 2025 J. Kirby Ross / Neuroglyph Collective */
 
 #define _POSIX_C_SOURCE 200809L

--- a/tests/e2e/01_core_functionality.sh
+++ b/tests/e2e/01_core_functionality.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: LicenseRef-MIND-UCAL-1.0
+# © 2025 J. Kirby Ross / Neuroglyph Collective
 
 # Core Functionality E2E Tests
 

--- a/tests/e2e/02_edge_cases.sh
+++ b/tests/e2e/02_edge_cases.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: LicenseRef-MIND-UCAL-1.0
+# © 2025 J. Kirby Ross / Neuroglyph Collective
 
 # Freaky Edge Cases E2E Tests
 

--- a/tests/e2e/03_performance_benchmarks.sh
+++ b/tests/e2e/03_performance_benchmarks.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: LicenseRef-MIND-UCAL-1.0
+# © 2025 J. Kirby Ross / Neuroglyph Collective
 
 # Performance Benchmarks - Make Linus Respect You
 

--- a/tests/e2e/run_all_tests.sh
+++ b/tests/e2e/run_all_tests.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: LicenseRef-MIND-UCAL-1.0
+# © 2025 J. Kirby Ross / Neuroglyph Collective
 
 # Run all E2E tests
 

--- a/tests/e2e/test_augments.sh
+++ b/tests/e2e/test_augments.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: LicenseRef-MIND-UCAL-1.0
 # © 2025 J. Kirby Ross / Neuroglyph Collective
 
 # E2E test for AUGMENTS system

--- a/tests/e2e/test_framework.sh
+++ b/tests/e2e/test_framework.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: LicenseRef-MIND-UCAL-1.0
+# © 2025 J. Kirby Ross / Neuroglyph Collective
 
 # E2E Test Framework for git-mind
 # No bullshit, just POSIX shell and raw performance

--- a/tests/integration/test_behavior.sh
+++ b/tests/integration/test_behavior.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: LicenseRef-MIND-UCAL-1.0
+# © 2025 J. Kirby Ross / Neuroglyph Collective
 
 # Integration test suite - Test BEHAVIOR not implementation
 


### PR DESCRIPTION
Replaces Apache 2.0 with ethical restrictions preventing:
- Military/weapons applications
- Mass surveillance systems
- Behavioral manipulation
- Extractive commercial exploitation
- Violations of personhood

BREAKING CHANGE: New license restrictions may affect some use cases