### PR TITLE
fix: thread-unsafe global state in id.c

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -5,7 +5,7 @@
 CC ?= gcc
 CFLAGS = -Wall -Wextra -Werror -std=gnu11 -O2
 CFLAGS += -I./include
-LDFLAGS = -lsodium
+LDFLAGS = -lsodium -lpthread
 
 # Coverage settings
 COVERAGE ?= 0
@@ -75,7 +75,7 @@ $(OBJ_DIR)/%.o: $(SRC_DIR)/%.c
 test: dirs $(ALL_OBJS)
 	$(CC) $(CFLAGS) $(TEST_ERROR) $(ERROR_OBJS) -o $(BIN_DIR)/test_error $(LDFLAGS)
 	$(CC) $(CFLAGS) $(TEST_ID) $(TYPES_OBJS) $(CRYPTO_OBJS) $(UTF8_OBJS) $(ERROR_OBJS) -o $(BIN_DIR)/test_id $(LDFLAGS)
-	$(CC) $(CFLAGS) $(TEST_ID_THREAD_SAFETY) $(TYPES_OBJS) $(CRYPTO_OBJS) $(UTF8_OBJS) $(ERROR_OBJS) -o $(BIN_DIR)/test_id_thread_safety $(LDFLAGS) -lpthread
+	$(CC) $(CFLAGS) $(TEST_ID_THREAD_SAFETY) $(TYPES_OBJS) $(CRYPTO_OBJS) $(UTF8_OBJS) $(ERROR_OBJS) -o $(BIN_DIR)/test_id_thread_safety $(LDFLAGS)
 	$(CC) $(CFLAGS) $(TEST_STRING) $(TYPES_OBJS) $(CRYPTO_OBJS) $(UTF8_OBJS) $(ERROR_OBJS) -o $(BIN_DIR)/test_string $(LDFLAGS)
 	$(CC) $(CFLAGS) $(TEST_PATH) $(TYPES_OBJS) $(CRYPTO_OBJS) $(UTF8_OBJS) $(ERROR_OBJS) -o $(BIN_DIR)/test_path $(LDFLAGS)
 	$(CC) $(CFLAGS) $(TEST_SHA256) $(CRYPTO_OBJS) $(ERROR_OBJS) -o $(BIN_DIR)/test_sha256 $(LDFLAGS)


### PR DESCRIPTION
## Summary
- Replace race-prone boolean flag with pthread_once for SipHash key initialization
- Ensures the key is initialized exactly once even with concurrent access
- Fixes TODO #1 (HIGH PRIORITY) from TASKLIST.md

## Changes
- Replace `g_siphash_key_initialized` flag with `pthread_once_t`
- Use `pthread_once()` to guarantee single initialization 
- Add pthread to LDFLAGS in Makefile
- Free error on fallback path to prevent memory leak

## Test Plan
- [x] All existing tests pass
- [x] Thread safety test (`test_id_thread_safety`) verifies concurrent access
- [x] No new compiler warnings
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.ai/code)