### PR TITLE
fix(crypto): replace generic sodium.h with specific headers

### DIFF
--- a/core/include/gitmind/types/id.h
+++ b/core/include/gitmind/types/id.h
@@ -29,8 +29,8 @@ typedef struct gm_id {
 GM_RESULT_DEF(gm_result_id, gm_id_t);
 
 /* ID operations */
-bool gm_id_equal(gm_id_t a, gm_id_t b);
-int gm_id_compare(gm_id_t a, gm_id_t b);
+bool gm_id_equal(gm_id_t id_a, gm_id_t id_b);
+int gm_id_compare(gm_id_t id_a, gm_id_t id_b);
 gm_result_u32 gm_id_hash(gm_id_t id);
 
 /* ID creation - all can fail */

--- a/core/src/crypto/backend.c
+++ b/core/src/crypto/backend.c
@@ -7,7 +7,9 @@
 #include "gitmind/error.h"
 #include "gitmind/security/memory.h"
 
-#include <sodium.h>
+#include <sodium/crypto_hash_sha256.h>
+#include <sodium/randombytes.h>
+#include <sodium/core.h>
 #include <string.h>
 
 /* Test backend constants */


### PR DESCRIPTION
- Use specific libsodium headers instead of umbrella include
- backend.c: crypto_hash_sha256.h, randombytes.h, core.h
- Eliminates misc-include-cleaner warnings for unused includes
- Fix parameter naming in id.h (id_a, id_b instead of a, b)
- Reduces warning count by 13 (401 → 388)
