### PR TITLE
sprint1/cli invalid path errors

### DIFF
--- a/apps/cli/cli/link.md
+++ b/apps/cli/cli/link.md
@@ -62,6 +62,7 @@ Error: Path not found: missing.md
 $ mkdir dir && git-mind link README.md dir
 Error: Not a regular file: dir
 
+Note: "regular file" excludes directories, FIFOs, devices. Clarify symlink behavior (accepted/rejected).
 $ git-mind link 
 Usage: git-mind link <source> <target> [--type <type>]
 Types: implements, references, depends_on, augments

--- a/apps/cli/cli/link.md
+++ b/apps/cli/cli/link.md
@@ -54,7 +54,13 @@ Clear feedback:
 ### Error Cases
 ```bash
 $ git-mind link missing.md README.md
-Error: Not found
+Error: Path not found: missing.md
+
+$ git-mind link README.md missing.md
+Error: Path not found: missing.md
+
+$ mkdir dir && git-mind link README.md dir
+Error: Not a regular file: dir
 
 $ git-mind link 
 Usage: git-mind link <source> <target> [--type <type>]
@@ -62,6 +68,7 @@ Types: implements, references, depends_on, augments
 ```
 
 Helpful errors:
+- Specific path names in messages
 - Brief error message
 - Usage hint when args missing
 - List valid types

--- a/apps/cli/cli/link.md
+++ b/apps/cli/cli/link.md
@@ -68,6 +68,7 @@ Types: implements, references, depends_on, augments
 ```
 
 Helpful errors:
+
 - Specific path names in messages
 - Brief error message
 - Usage hint when args missing

--- a/docs/code-reviews/rejected-suggestions/08721f36546cea08d790d4ed2fd3b1afd9125f92_sprint1-cli-invalid-path-errors_164_core-path-validation-refactor.md
+++ b/docs/code-reviews/rejected-suggestions/08721f36546cea08d790d4ed2fd3b1afd9125f92_sprint1-cli-invalid-path-errors_164_core-path-validation-refactor.md
@@ -5,20 +5,26 @@ Original comment
 - https://github.com/neuroglyph/git-mind/pull/164#discussion_r2346005404
 
 Rationale for rejection
+
 - This PR is scoped to CLI error messaging for invalid paths. Moving validation into core is desirable but touches public API and multiple call sites; we prefer to land the CLI fix first and do the core refactor in a focused follow‑up.
 
 What you did instead
+
 - Kept a small helper in the CLI (`validate_path_is_regular_file`) and reduced duplication. Behavior preserved; clearer errors.
 
 Tradeoffs considered
+
 - Pros: Smaller, safer diff; unblocks this PR.
 - Cons: Validation is not yet reusable by other commands.
 
 What would make you change your mind
+
 - A follow‑up PR to add `gm_path_validate_*` APIs in core with tests and CLI adoption.
 
 Future Plans
+
 - Track a core refactor task to introduce standardized path helpers under `core/include/gitmind/path.h`.
 
 Confidence
+
 - 7/10. A small, localized change that improves clarity without expanding scope.

--- a/docs/code-reviews/rejected-suggestions/08721f36546cea08d790d4ed2fd3b1afd9125f92_sprint1-cli-invalid-path-errors_164_core-path-validation-refactor.md
+++ b/docs/code-reviews/rejected-suggestions/08721f36546cea08d790d4ed2fd3b1afd9125f92_sprint1-cli-invalid-path-errors_164_core-path-validation-refactor.md
@@ -1,0 +1,24 @@
+Summary
+- Suggestion: Centralize path validation in core for reuse.
+
+Original comment
+- https://github.com/neuroglyph/git-mind/pull/164#discussion_r2346005404
+
+Rationale for rejection
+- This PR is scoped to CLI error messaging for invalid paths. Moving validation into core is desirable but touches public API and multiple call sites; we prefer to land the CLI fix first and do the core refactor in a focused follow‑up.
+
+What you did instead
+- Kept a small helper in the CLI (`validate_path_is_regular_file`) and reduced duplication. Behavior preserved; clearer errors.
+
+Tradeoffs considered
+- Pros: Smaller, safer diff; unblocks this PR.
+- Cons: Validation is not yet reusable by other commands.
+
+What would make you change your mind
+- A follow‑up PR to add `gm_path_validate_*` APIs in core with tests and CLI adoption.
+
+Future Plans
+- Track a core refactor task to introduce standardized path helpers under `core/include/gitmind/path.h`.
+
+Confidence
+- 7/10. A small, localized change that improves clarity without expanding scope.

--- a/docs/testing/Test_Plan.md
+++ b/docs/testing/Test_Plan.md
@@ -13,6 +13,7 @@ Testing emphasizes determinism, backward compatibility, and performance. Targets
 ## Coverage Goals
 - Unit: ≥ 80% for new/changed core (IDs, CBOR, cache routing)
 - Integration: Exercise CLI flows (link, list, cache-rebuild, cohesion-report)
+  - CLI error handling: invalid paths for link produce clear messages identifying the offending path; directory paths are rejected
 - E2E: Repo-level tests with small synthetic graphs; branch merge scenarios
 
 ## Test Scenarios for Critical Paths
@@ -28,6 +29,10 @@ Testing emphasizes determinism, backward compatibility, and performance. Targets
 - Cohesion Report
   - Scalar flips and set diffs across simulated merges
   - Depth capping for `implies` chains; cycle detection
+- CLI Error Handling
+  - `git-mind link` with missing source/target prints `Error: Path not found: <path>` and exits non-zero
+  - `git-mind link` with a directory as source/target prints `Error: Not a regular file: <path>` and exits non-zero
+  - E2E coverage in `tests/e2e/02_edge_cases.sh:test_invalid_path_errors`
 - Advice Merge (if enabled)
   - LWW and OR-Set behaviors; tombstone wins/remains until re-added
 

--- a/docs/testing/Test_Plan.md
+++ b/docs/testing/Test_Plan.md
@@ -30,9 +30,11 @@ Testing emphasizes determinism, backward compatibility, and performance. Targets
   - Scalar flips and set diffs across simulated merges
   - Depth capping for `implies` chains; cycle detection
 - CLI Error Handling
+
   - `git-mind link` with missing source/target prints `Error: Path not found: <path>` and exits non-zero
   - `git-mind link` with a directory as source/target prints `Error: Not a regular file: <path>` and exits non-zero
   - E2E coverage in `tests/e2e/02_edge_cases.sh:test_invalid_path_errors`
+
 - Advice Merge (if enabled)
   - LWW and OR-Set behaviors; tombstone wins/remains until re-added
 

--- a/include/gitmind/constants.h
+++ b/include/gitmind/constants.h
@@ -60,6 +60,9 @@
 #define GM_ERR_WRITE_FAILED "Error: Failed to write link"
 #define GM_ERR_INVALID_CONF "Error: Invalid confidence value (must be 0.0-1.0)"
 #define GM_ERR_PARSE_ARGS "Error: Failed to parse arguments"
+/* Path validation errors */
+#define GM_ERR_PATH_NOT_FOUND "Error: Path not found: %s"
+#define GM_ERR_NOT_REGULAR_FILE "Error: Not a regular file: %s"
 
 /* Format buffer sizes */
 #define GM_FORMAT_BUFFER_SIZE 512

--- a/tests/e2e/02_edge_cases.sh
+++ b/tests/e2e/02_edge_cases.sh
@@ -15,19 +15,19 @@ test_invalid_path_errors() {
     init_test_repo "invalid-paths"
 
     # No files yet; linking should fail with clear message for source
-    assert_failure "gm link missing.md other.md"
-    assert_contains "gm link missing.md other.md" "Error: Path not found: missing.md"
+    assert_failure "$GIT_MIND link missing.md other.md"
+    assert_contains "$GIT_MIND link missing.md other.md" "Error: Path not found: missing.md"
 
     # Create source, leave target missing
     create_file "exists.md" "content"
     commit "Add exists.md"
-    assert_failure "gm link exists.md other.md"
-    assert_contains "gm link exists.md other.md" "Error: Path not found: other.md"
+    assert_failure "$GIT_MIND link exists.md other.md"
+    assert_contains "$GIT_MIND link exists.md other.md" "Error: Path not found: other.md"
 
     # Directory instead of regular file should fail
     mkdir -p dir
-    assert_failure "gm link exists.md dir"
-    assert_contains "gm link exists.md dir" "Error: Not a regular file: dir"
+    assert_failure "$GIT_MIND link exists.md dir"
+    assert_contains "$GIT_MIND link exists.md dir" "Error: Not a regular file: dir"
 }
 
 # Test 1: Same Content, Different Paths

--- a/tests/e2e/02_edge_cases.sh
+++ b/tests/e2e/02_edge_cases.sh
@@ -8,6 +8,28 @@ source "$(dirname "$0")/test_framework.sh"
 
 echo "=== FREAKY EDGE CASES ==="
 
+# Test 0: Helpful errors for invalid paths
+test_invalid_path_errors() {
+    echo -e "\n${YELLOW}Test 0: Helpful Errors for Invalid Paths${NC}"
+
+    init_test_repo "invalid-paths"
+
+    # No files yet; linking should fail with clear message for source
+    assert_failure "gm link missing.md other.md"
+    assert_contains "gm link missing.md other.md" "Error: Path not found: missing.md"
+
+    # Create source, leave target missing
+    create_file "exists.md" "content"
+    commit "Add exists.md"
+    assert_failure "gm link exists.md other.md"
+    assert_contains "gm link exists.md other.md" "Error: Path not found: other.md"
+
+    # Directory instead of regular file should fail
+    mkdir -p dir
+    assert_failure "gm link exists.md dir"
+    assert_contains "gm link exists.md dir" "Error: Not a regular file: dir"
+}
+
 # Test 1: Same Content, Different Paths
 test_same_content_different_paths() {
     echo -e "\n${YELLOW}Test 1: Same Content, Different Paths${NC}"
@@ -354,6 +376,7 @@ test_journal_merge() {
 }
 
 # Run all edge case tests
+test_invalid_path_errors
 test_same_content_different_paths
 test_same_path_different_content
 test_rebase_scenarios


### PR DESCRIPTION
feat(cli/link): helpful errors for invalid paths\n\nSummary\n- Add clear CLI messages for invalid paths in :\n  - Error: Path not found: <path>\n  - Error: Not a regular file: <path>\n- Pre-validate both source and target before edge creation; exit non-zero on failure\n- Docs updated: link.md error cases, Test Plan coverage\n- E2E tests added in tests/e2e/02_edge_cases.sh (invalid-paths)\n\nTests\n- Unit tests remain green (Meson/Ninja)\n- E2E tests added but not wired into CI yet, pending CLI build target integration. Intend to wire once CLI Meson target compiles cleanly (umbrella header alignment needed).\n\nCI\n- Standard build/test jobs pass; clang-tidy unaffected.\n\nFollow-ups\n- Add CLI Meson target (resolve header duplication between include/gitmind.h and core headers) and wire E2E to CI.\n- Optionally show which path fails when gm_edge creation fails inside core (for completeness).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Link command now validates paths, reports "Error: Path not found: <path>" or "Error: Not a regular file: <path>", and prevents link creation for invalid inputs.

- **Documentation**
  - Link docs clarified with path-specific error messages, a note on what counts as a regular file (symlink behavior), and a rationale doc for the chosen approach.

- **Tests**
  - Added end-to-end test covering invalid-path scenarios for the link command.

- **Chores**
  - New error message constants added for path-validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->