### PR TITLE
docs(memory): add allocation architecture references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -426,6 +426,11 @@ Every outbound port ships with: (a) production adapter, (b) deterministic fake u
 See archives under `docs/activity/` for older logs.
 
 ### 2025-10-08
+- PR177 feedback sweep
+  - Hardened telemetry handling across cache rebuild and journal read paths (checked `gm_telemetry_cfg_load`, formatter fallbacks, safe `gm_snprintf` handling) and zeroed log buffers on every error branch.
+  - Introduced `core/tests/support/temp_repo_helpers.h`, migrated libgit2-heavy “unit” tests into `core/tests/integration/`, and tagged them in Meson so we have a clean integration suite.
+  - Tightened fake ports/tests (metrics, diagnostics, CLI env, cache telemetry) to treat truncation as fatal and removed the legacy auto review-seeding workflow.
+  - `make ci-local` green after the restructuring; pushed `e471420` to `feat/hex-ports-ci-green` (PR #177).
 - Telemetry & logging
   - Added internal telemetry config shim (`core/include/gitmind/telemetry/internal/config.h`, `core/src/telemetry/config.c`).
   - Implemented repo tag hashing flag `GITMIND_METRICS_REPO_HASH_ALGO=sha256|fnv` (default `fnv`); tests cover `sha256` path.

--- a/core/tests/unit/test_fs_temp_port.c
+++ b/core/tests/unit/test_fs_temp_port.c
@@ -45,6 +45,8 @@ int main(void) {
     gm_repo_id_t repo_id = {0};
     gm_result_void_t repo_id_result = gm_repo_id_from_path(canon, &repo_id);
     assert(repo_id_result.ok);
+    free((void *)canon);
+    canon = NULL;
 
     gm_tempdir_t tempdir = {0};
     gm_result_void_t temp_result = gm_fs_temp_port_make_temp_dir(
@@ -70,6 +72,8 @@ int main(void) {
         gm_fs_temp_port_canonicalize(&port, logical_input, &logical_out);
     assert(logical_result.ok);
     assert(strcmp(logical_out, tempdir_real) == 0);
+    free((void *)logical_out);
+    logical_out = NULL;
 
     gm_fs_canon_opts_t existing_opts = {.mode = GM_FS_CANON_PHYSICAL_EXISTING};
     const char *physical_out = NULL;
@@ -77,6 +81,8 @@ int main(void) {
         &port, tempdir_real, existing_opts, &physical_out);
     assert(physical_result.ok);
     assert(strcmp(physical_out, tempdir_real) == 0);
+    free((void *)physical_out);
+    physical_out = NULL;
 
     char create_target[GM_PATH_MAX];
     int create_status = snprintf(create_target, sizeof(create_target),
@@ -88,6 +94,8 @@ int main(void) {
         &port, create_target, create_opts, &create_out);
     assert(create_ok_result.ok);
     assert(strstr(create_out, "/new-entry") != NULL);
+    free((void *)create_out);
+    create_out = NULL;
 
     const char *missing_out = NULL;
     gm_fs_canon_opts_t missing_opts = {.mode = GM_FS_CANON_PHYSICAL_EXISTING};
@@ -142,12 +150,16 @@ int main(void) {
         &fake.port, fake_dir.path, fake_opts, &fake_logical);
     assert(fake_logical_res.ok);
     assert(strcmp(fake_logical, fake_dir.path) == 0);
+    free((void *)fake_logical);
+    fake_logical = NULL;
 
     gm_fs_canon_opts_t fake_phys = {.mode = GM_FS_CANON_PHYSICAL_EXISTING};
     const char *fake_phys_out = NULL;
     gm_result_void_t fake_phys_res = gm_fs_temp_port_canonicalize_ex(
         &fake.port, fake_dir.path, fake_phys, &fake_phys_out);
     assert(fake_phys_res.ok);
+    free((void *)fake_phys_out);
+    fake_phys_out = NULL;
 
     gm_result_void_t fake_remove =
         gm_fs_temp_port_remove_tree(&fake.port, fake_dir.path);

--- a/docs/architecture/Memory Allocation Strategies.md
+++ b/docs/architecture/Memory Allocation Strategies.md
@@ -1,0 +1,310 @@
+---
+title: Technical Decision — Memory Allocation Strategy
+description: Formal decision, requirements, and design for GitMind’s memory allocation & ownership model. Includes enforcement & migration plan.
+audience: [contributors, maintainers]
+domain: [architecture]
+tags: [memory, hexagonal-architecture, testing, reliability, performance]
+status: accepted
+last_updated: 2025-10-08
+---
+<!-- SPDX-License-Identifier: LicenseRef-MIND-UCAL-1.0 -->
+<!-- © 2025 J. Kirby Ross / Neuroglyph Collective -->
+
+# Memory Allocation Strategies
+
+## **1) Decision Summary (The Short, Sharp Bit)**
+
+- **Allocator is a port** injected via gm_context_t (no raw malloc in domain/services). Default wraps system malloc; tests can swap in arenas/fakes/tracers.
+- **Operation-scoped arenas** for bursty, short-lived allocations (e.g., cache rebuilds, attribution scans, journal decodes).
+- **Small-object slabs** for hot bins (32/64/128/256 bytes) used by errors, telemetry kv pairs, tiny edge pods.
+- **String & OID interning** (service lifetime) with refcounted handles; pointer equality implies value equality.
+- **Explicit ownership protocol** via suffixes: _owned (caller frees), _borrowed (callee owns), _view (slice; parent controls lifetime). Ports that return heap also ship a *_free or a result_ptr{ptr,dtor}.
+- **Allocation telemetry**: bytes outstanding, peak bytes, alloc failure count, per-operation tags; budgets enforced in CI.
+
+These choices give us predictably low latency, bounded peaks, easy failure injection, and contributor-friendly lifetimes—without a language rewrite.
+
+## **2) Why These Choices (and Why Not the Others)**
+
+### **2.1 Allocator as a Port**
+
+**Why:** enables testable failure modes (Nth-alloc OOM), swap-in backends (jemalloc/tracing), and keeps memory in the infrastructure ring with FS/Logger/Metrics.
+
+**Not chosen:** raw malloc (un-auditable), global singleton allocators (hidden state/test bleed), “just jemalloc globally” (helps fragmentation, not lifetimes or tests).
+
+### **2.2 Operation-Scoped Arenas**
+
+**Why:** O(1) teardown, near-zero fragmentation, tight cache locality for big scans and rebuilds.
+
+**Not chosen:** hand-free everything (brittle), RC/GC (complex/pausy), TLS scratch everywhere (hidden state; test pain).
+
+### **2.3 Small-Object Slabs**
+
+**Why:** tiny hot structs dominate counts; slab bins de-jitter latency and reduce fragmentation.
+
+**Not chosen:** buddy allocators (page-oriented; poor for sub-256B), per-type freelists (surface-area explosion).
+
+### **2.4 Interning (paths, branch names, SHAs/OIDs)**
+
+**Why:** dedup by construction, identity semantics, fewer long-lived duplicates.
+
+**Not chosen:** global tables (contention), rope/rope-like strings (overhead; slicing rules everywhere).
+
+### **2.5 Ownership Protocol + result_ptr**
+
+**Why:** reviewable lifetimes by name; doc-lintable; portable C idiom.
+
+**Not chosen:** “we’ll document it” (people forget), pervasive smart-pointer emulation (hidden costs; boilerplate).
+
+### **2.6 Alloc Telemetry + Budgets**
+
+**Why:** measurable, enforceable targets; catch regressions early; op-scoped attribution.
+
+**Not chosen:** profiler-only culture (not CI-able), ad-hoc logs (noisy, unstructured).
+
+> Alternative path we _will_ benchmark for due diligence: **jemalloc under the port + ownership protocol, no arenas**. Expect we’ll still adopt arenas for rebuild/scan flows due to O(1) teardown wins.
+
+## **3) Requirements (Normative)**
+
+### **3.1 Allocator Port**
+
+- Define `gm_allocator_port_t` with `alloc`/`realloc`/`free`, `ctx` cookie, optional diagnostics: `bytes_outstanding()`, `peak_bytes()`, `failures_total()`.
+- Expose `gm_xalloc(alloc,n)`, `gm_xcalloc`, `gm_xrealloc`, `gm_xfree` wrappers.
+- `gm_context_t` must carry an allocator instance; all service/adapter code uses it (no raw `malloc`/`free`).
+
+#### **Header (new)**
+
+- `gitmind/ports/allocator_port.h` — public port
+- `gitmind/util/alloc_wrappers.h` — inline helpers
+
+### **3.2 Arenas**
+
+- `gm_arena_begin(alloc, hint_bytes)` -> `gm_arena_t*`, `gm_arena_alloc(arena, size, align)`, `gm_arena_end(arena)`.
+- Growth: geometric (×2) until cap; fail with `gm_result_*` on cap hit.
+- **No per-object frees**; objects from arenas must not escape operation scope.
+- **Defaults** (tunable via config/env):
+    - `ARENA_HINT_CACHE_REBUILD=8 MiB`, `ARENA_CAP_CACHE_REBUILD=256 MiB`
+    - `ARENA_HINT_ATTR_QUERY=4 MiB`, `ARENA_CAP_ATTR_QUERY=128 MiB`
+
+#### **Header (new)**
+
+- `gitmind/util/arena.h`
+
+### **3.3 Small-Object Slabs**
+
+- Bins: 32/64/128/256 bytes (aligned); superblock = 64 KiB; return whole superblock when fully free.
+- Public API opaque; consumers call `gm_slab_alloc(size)`; sizes outside bins fall back to base allocator.
+
+#### **Header (new)**
+
+- `gitmind/util/slab.h`
+
+### **3.4 Intern Tables**
+
+- Tables per service (e.g., `cache`, `journal`): `gm_intern_table_t* gm_intern_table_new(alloc)`.
+- `gm_intern_acquire(tbl, "string", &out_handle)`, `gm_intern_retain`, `gm_intern_release`.
+- Expose `gm_intern_ptr(handle)`; pointer validity tied to table lifetime.
+
+#### **Header (new)**
+
+- `gitmind/util/intern.h`
+
+### **3.5 Ownership Protocol**
+
+- Function return types carrying heap must either:
+    - Return _owned pointers with a matching *_free, **or**
+    - Return `gm_result_ptr_t { void* ptr; void (*destroy)(void*); }`.
+- Borrowed and view lifetimes must be suffix-annotated in the symbol name and documented in headers.
+- CI doc-lint enforces suffix rules and presence of destroyer.
+
+### **3.6 Telemetry**
+
+- Allocator exposes metrics; services tag ops: `cache.rebuild`, `attr.query`, `journal.read`.
+- Emit per-op: `alloc.peak_bytes`, `alloc.failures_total`, `arena.grow.bytes (sampled)`.
+- Budgets enforced in CI by operation type (see §6).
+
+## **4) Design (Informative, but specific)**
+
+## **4.1 Interfaces**
+
+```c
+// ports/allocator_port.h
+typedef void* (*gm_alloc_fn)(void* ctx, size_t n);
+typedef void* (*gm_realloc_fn)(void* ctx, void* p, size_t n);
+typedef void  (*gm_free_fn)(void* ctx, void* p);
+
+typedef struct {
+  void*           ctx;
+  gm_alloc_fn     alloc;
+  gm_realloc_fn   realloc;
+  gm_free_fn      free;
+  // optional diagnostics:
+  uint64_t      (*bytes_outstanding)(void* ctx);
+  uint64_t      (*peak_bytes)(void* ctx);
+  uint64_t      (*failures_total)(void* ctx);
+} gm_allocator_port_t;
+
+typedef struct {
+  void*  ptr;
+  void (*destroy)(void*);
+} gm_result_ptr_t;
+```
+
+```c
+// util/arena.h (sketch)
+typedef struct gm_arena gm_arena_t;
+gm_arena_t* gm_arena_begin(const gm_allocator_port_t* alloc, size_t hint, size_t cap);
+void*       gm_arena_alloc(gm_arena_t* a, size_t size, size_t align);
+void        gm_arena_reset(gm_arena_t* a); // optional reuse
+void        gm_arena_end(gm_arena_t* a);
+```
+
+```c
+// util/slab.h (sketch)
+void* gm_slab_alloc(const gm_allocator_port_t* alloc, size_t size);
+void  gm_slab_free (const gm_allocator_port_t* alloc, void* p, size_t size);
+```
+
+```c
+// util/intern.h (sketch)
+typedef struct gm_intern_handle { uint32_t id; } gm_intern_handle_t;
+typedef struct gm_intern_table gm_intern_table_t;
+
+gm_intern_table_t* gm_intern_table_new(const gm_allocator_port_t* alloc);
+void               gm_intern_table_free(gm_intern_table_t* t);
+
+gm_result_t gm_intern_acquire(gm_intern_table_t* t, const char* s, gm_intern_handle_t* out);
+void        gm_intern_retain (gm_intern_table_t* t, gm_intern_handle_t h);
+void        gm_intern_release(gm_intern_table_t* t, gm_intern_handle_t h);
+const char* gm_intern_ptr    (const gm_intern_table_t* t, gm_intern_handle_t h);
+```
+
+### **4.2 Integration Points (current code)**
+
+- **Temp FS adapters** (`posix_temp_adapter.c`, `fake_fs_temp_port.c`) must consume allocator port and return _owned canonical paths with explicit *_free.
+- **Cache rebuild service** (`cache_rebuild_service.c`): wrap main routine in `gm_arena_begin`/`end`; move temp buffers and decoded structs into arena.
+- **Reader/Writer** (`reader.c`, `writer.c`): journal decode/encode scratch → arena; small error payloads & log kvs → slab; stable names (paths/refs) → intern table.
+  
+### **4.3 Threading & Concurrency**
+
+- No global allocators; allocator lives in `gm_context_t`.
+- Arenas are per-operation; never shared across threads.
+- Intern tables are per service; guard with fine-grained locks or sharded tables if contention appears (future enhancement).
+
+### **4.4 Security & Safety**
+
+- Maintain `gm_snprintf`/`gm_strcpy_safe` policy. Treat truncation as error.
+- Zero sensitive buffers on free for security-critical payloads (journal secrets, keys).
+- Never allocate within signal handlers; never free across allocator instances.
+
+## **5) Enforcement (Tooling & CI)**
+
+### **5.1 Linting & Static Checks**
+
+- **Forbidden**: direct `malloc`/`calloc`/`realloc`/`free` in non-allocator units (clang-tidy pattern-list + CI grep).
+- **Header policy**: if a function returns `*` and includes _owned in its name, linter checks for a sibling *_free symbol.
+- **Suffix check**: exported symbols returning views must end with _view; borrowed refs with _borrowed.
+
+### **5.2 Test Fakes & Harness**
+
+- **OOM-after-N allocator**: configurable via env (`GM_TEST_OOM_N`); used in unit and integration tests across services.
+- **Tracing allocator**: asserts `bytes_outstanding()==0` at test end; CI fails on leaks.
+- **Concurrency smoke**: run parallel cache rebuilds using separate arenas; assert no cross-talk, record per-op peaks.
+
+### **5.3 Budgets in CI**
+
+- Cache rebuild: `peak_bytes <= 256 MiB` (warn at 80%, fail at 100%).
+- Attribution scan (standard repo fixture): `peak_bytes <= 128 MiB`.
+- Any alloc failure count > 0 outside OOM tests => fail.  
+> Budgets are recorded per op name; telemetry exporter already exists—wire allocator metrics to it and gate in CI.
+
+## **6) Migration Plan (Three Focused PRs)**
+
+### **PR-1: Allocator Port + Wiring (Infrastructure)**
+
+- Add `allocator_port.h`/`alloc_wrappers.h`; inject into `gm_context_t`.
+- Convert temp FS code paths to use the port; return _owned buffers + gm_fs_*_free.
+- CI: add forbidden-API check for raw malloc/free.
+
+### **PR-2: Arenas in Cache Rebuild (Service)**
+
+- Wrap rebuild service call chain with `gm_arena_begin`/`end`.
+- Move temp structs/buffers to `gm_arena_alloc`.
+- Emit `alloc.peak_bytes` per rebuild; add CI budget check.
+
+### **PR-3: Slabs + Interning (Cross-cutting)**
+
+- Introduce `slab.h` and route `gm_error_t`, telemetry `kv` structs, and other ≤256B pods.
+- Add `intern.h` and replace repeated path/branch/OID strings with interned handles in hot services.
+- Add histogram instrumentation for alloc sizes; tune bins in follow-up PR.
+
+## **7) Alternatives Considered (and Rejected)**
+
+- **Rust rewrite now:** wins ownership at compile time; loses calendar. Keep this design to ease a future Rust module boundary. Plus, this is a C project. Get outta here!
+- **`jemalloc` everywhere only:** keep it under the port as a default backend; still need arenas/ownership.
+- **Conservative GC:** unpredictable pauses; pointer ambiguity; not CI-friendly.
+- **TLS scratch allocators:** tempting latency win; encourages hidden state; hard to test/trace; we’ll use arenas instead.
+
+## **8) Operational Guidance (Daily Use)**
+
+- Domain ring: avoid heap entirely.
+- If you return heap, you **must** expose a destroyer and annotate ownership in the name.
+- Anything outliving an operation must **not** come from an arena (duplicate to service allocator or intern it).
+- On error, **one cleanup: path** frees in reverse order; owned outputs are zeroed on failure.
+
+## **9) Acceptance Criteria**
+
+- No direct `malloc`/`calloc`/`realloc`/`free` calls remain in touched modules (enforced in CI).
+- Cache rebuild & attribution tests pass with OOM-after-N at multiple thresholds.    
+- CI enforces peak-memory budgets; failures provide op-scoped metrics.
+- Headers export _owned/_borrowed/_view consistently; lint is green.
+- Bench: equal or better P50/P99 for rebuilds and scans; memory peaks stable across runs.
+
+---
+
+## **Appendix A — Code Skeletons (Drop-in)**
+
+```c
+// gm_result_ptr helpers
+static inline gm_result_ptr_t gm_result_ptr(void* p, void(*d)(void*)) {
+  gm_result_ptr_t r = { .ptr = p, .destroy = d }; return r;
+}
+static inline void gm_result_ptr_free(gm_result_ptr_t* rp) {
+  if (rp && rp->ptr && rp->destroy) rp->destroy(rp->ptr);
+  if (rp) rp->ptr = NULL, rp->destroy = NULL;
+}
+```
+
+```c
+// OOM-after-N fake (diagnostics ctx carries a countdown)
+typedef struct { const gm_allocator_port_t* base; uint64_t n_left; } gm_oom_after_n_t;
+static void* oom_alloc(void* ctx, size_t n) {
+  gm_oom_after_n_t* s = ctx; if (s->n_left && --s->n_left==0) return NULL;
+  return s->base->alloc(s->base->ctx, n);
+}
+// … implement realloc/free similarly and plug diagnostics counters.
+```
+
+```c
+// Tracing allocator (bytes_outstanding/peak)
+typedef struct { const gm_allocator_port_t* base; uint64_t out, peak, fails; } gm_trace_alloc_t;
+static void* trace_alloc(void* c, size_t n){ gm_trace_alloc_t*s=c; void*p=s->base->alloc(s->base->ctx,n);
+  if(!p){s->fails++;return NULL;} s->out+=n; if(s->out>s->peak)s->peak=s->out; return p; }
+```
+
+---
+
+# **Appendix B — Policy Lint (cheap & cheerful)**
+
+- **No raw allocs:** `rg -n "(^|[^_])\b(malloc|calloc|realloc|free)\b" --glob '!**/util/**'`
+- **Owned requires destroy:** script parses public headers; for any *_owned return, assert a *_free exists.
+- **Suffixes:** `rg -n ".*_view\("` in headers; check docs include lifetime note
+
+---
+
+# **Appendix C — Configuration**
+
+- Env overrides:    
+    - `GM_ARENA_HINT_CACHE_REBUILD`, `GM_ARENA_CAP_CACHE_REBUILD`
+    - `GM_ARENA_HINT_ATTR_QUERY`, `GM_ARENA_CAP_ATTR_QUERY`
+    - `GM_TEST_OOM_N` for fail-injection in tests.
+- Telemetry tags: `alloc.op=cache.rebuild|attr.query|journal.read`.

--- a/docs/architecture/Memory_Allocation_Policy.md
+++ b/docs/architecture/Memory_Allocation_Policy.md
@@ -1,0 +1,120 @@
+<!-- SPDX-License-Identifier: LicenseRef-MIND-UCAL-1.0 -->
+<!-- © 2025 J. Kirby Ross / Neuroglyph Collective -->
+
+---
+title: Memory Allocation Policy
+description: Current ownership rules, allocation patterns, and exploratory ideas for future allocator work.
+audience: [contributors]
+domain: [architecture]
+tags: [memory, hexagonal-architecture]
+status: draft
+last_updated: 2025-10-09
+---
+
+# Memory Allocation Policy & Future Directions
+
+This note captures how the codebase currently allocates memory, the ownership contracts we rely on, and a set of exploratory ideas for improving safety and performance as the hexagonal migration continues. It is intentionally descriptive rather than prescriptive—where it suggests new mechanisms, treat them as options to evaluate, not commitments.
+
+## Table of Contents
+
+- Architectural Context
+- Current Allocation & Ownership Patterns
+- Requirements & Guardrails
+- Known Future Pressures
+- Exploratory Ideas (Non-Commitments)
+- Decision Checklist for Contributors
+- Open Questions
+
+## 1. Architectural Context
+
+- **Domain purity:** Modules under `core/src/domain/**` must remain allocation-free and deterministic. Any heap allocation happens in adapters or application services that sit outside the domain ring.
+- **Ports as seams:** Inbound/outbound ports define ownership. When a port method returns dynamically-allocated data, it must document the lifetime and ideally supply a matching `destroy`/`free` helper so callers cannot leak objects.
+- **Context wiring:** `gm_context_t` is the composition root. Today it owns concrete adapters (logger, metrics, fs temp, git repo). In the future it should also surface allocator configuration so application services can request memory without hard-coding `malloc`.
+- **Result types:** We represent fallible operations with `gm_result_*`. Any allocation failure must bubble up as a `gm_error_t`; caller code is responsible for freeing `result.u.err` when it does not propagate the error.
+
+## 2. Current Allocation & Ownership Patterns
+
+### 2.1 Stack-first buffers
+
+- Hot paths (logging, telemetry tags, ref strings) prefer stack buffers sized by policy constants (`GM_PATH_MAX`, 256 for log messages, etc.).
+- The helpers `gm_snprintf` and `gm_strcpy_safe` enforce truncation checks; callers clear buffers or abort work on failure.
+
+### 2.2 Ports returning heap memory
+
+- `gm_fs_temp_port_canonicalize_ex` now returns a heap-allocated canonical path. Callers must free the string after copying or when aborting.
+- Similar patterns exist (or will exist) for repo/branch introspection, staged temp directories, and future git-object adapters. Each port is responsible for documenting who frees the memory.
+
+### 2.3 Borrowed pointers
+
+- Some ports still hand out borrowed pointers into internal buffers (e.g., fake FS port scratch space) when the lifetime is aligned with the port call. We require callers to copy if they need longer-lived data. The long-term goal is to eliminate ambiguous borrowing in favor of explicit ownership or caller-supplied buffers.
+
+### 2.4 Ownership transfer in results
+
+- `gm_result_ptr_t` conveys ownership transfer for arbitrary pointers. The receiver is expected to free or otherwise dispose the pointer, often via a helper supplied by the module that produced it.
+- For structs (e.g., `gm_tempdir_t`), we encode ownership via embedded pointers: if `tempdir.path` is non-NULL, the adapter remains responsible for cleanup unless ownership is explicitly transferred (this is rare; keep it documented when it happens).
+
+### 2.5 Error objects as allocations
+
+- Every `gm_error_t` is heap-allocated. Ignoring a failed `gm_logger_log` or `gm_metrics_*` call leaks memory. Recent refactors ensure we capture and free those errors immediately after the log/metric attempt.
+
+## 3. Requirements & Guardrails
+
+1. **No hidden ownership:** Any function that returns heap memory must document who frees it and when. Prefer returning a `gm_result_ptr_t` or pairing the pointer with a destroy function pointer.
+2. **Single responsibility:** Allocate in the layer that owns lifetime decisions. Domain code never calls `malloc`; services/adapters may, but they must pair allocation with cleanup or transfer ownership explicitly.
+3. **Error-path hygiene:** On every failure path, clear or free partial allocations and reset output buffers (e.g., `out_path[0] = '\0'`).
+4. **Thread awareness:** New allocations must remain safe under concurrent use. If a helper caches buffers, it must be per-thread or guarded by synchronization.
+5. **Extensibility:** Upcoming adapters (git commit walkers, filesystem staging, hook runners) must be able to swap allocation strategies without changing domain code.
+
+## 4. Known Future Pressures
+
+- **Attribution pipelines:** Planned commit-walk adapters will build large in-memory graphs of author/time data. Expect a mix of short-lived iteration buffers and longer-lived aggregates suitable for pooling or arena allocation.
+- **Cache service evolution:** Cache rebuilds already materialize sizable maps; future enhancements (e.g., incremental snapshots, multi-branch rebuilds) will multiply concurrent allocations.
+- **Hook orchestration:** Process adapters may collect stdout/stderr logs of arbitrary length. We might need streaming buffers that grow without fragmenting the heap.
+- **Telemetry batching:** Moving toward structured telemetry could require short-lived allocations per event plus shared interned keys/values.
+
+## 5. Exploratory Ideas (Non-Commitments)
+
+### 5.1 Allocator Port
+
+Create a `gm_allocator_port_t` injected through `gm_context_t`. It would provide function pointers for `alloc`, `realloc`, `free`, and optional diagnostics. Default adapter wraps `malloc`. Tests could supply deterministic arenas to simulate OOM or track leaks.
+
+### 5.2 Arena allocators for services
+
+One idea might be to layer an arena per application service invocation (e.g., journal read, cache rebuild). All temporary allocations flow through the arena and are released wholesale once the operation completes. This helps bound lifetime and eliminates per-object frees.
+
+### 5.3 Small-object pools
+
+Given the prevalence of short-lived structs (telemetry kv pairs, log message buffers, edge metadata), we could offer a slab allocator tuned to common sizes. This would reduce fragmentation without complicating domain code.
+
+### 5.4 String/SHA interning
+
+Interning frequently repeated strings (paths, ref names) and SHA buffers could shrink the working set. A future `gm_intern_table_t` adapter could own a hash table that returns shared immutable slices. Consumers would hold references with explicit ref-counting or borrow semantics guarded by the allocator port.
+
+### 5.5 Reference-counted handles
+
+For data that survives beyond a single service call (e.g., cached snapshots handed to query ports), reference-counted handles might simplify lifetime management. We could define a lightweight `gm_ref_t` that pairs a pointer with release logic. Weak references are likely overkill for now, but the pattern could emerge if UI adapters need long-lived observers.
+
+### 5.6 Borrow checker protocols
+
+If we find frequent “borrow vs own” confusion, one idea might be to standardize naming: `*_borrowed` for pointers valid only within the call stack, `*_owned` for heap pointers that the caller must free, and `*_view` for immutable slices tied to another object’s lifetime.
+
+### 5.7 Telemetry of allocator usage
+
+We could instrument allocator adapters to emit metrics (total bytes, peak usage, allocation failures). This would help tune pool sizes and catch leaks during CI runs.
+
+## 6. Decision Checklist for Contributors
+
+- Does this code run in the domain ring? If yes, avoid heap allocation entirely.
+- Am I returning heap memory? Document the lifetime and add a destroy helper if one doesn’t exist.
+- Am I ignoring a `gm_result_*` from a logger/metrics/port call? Capture and free any embedded error.
+- Is there a clear cleanup path when the function exits early? Ensure buffers are cleared and allocations freed on every branch.
+- Would this benefit from a reusable allocator? If you see repeated patterns, log them here or open an issue so we can evaluate arena/slab adoption.
+
+## 7. Open Questions
+
+- Which services justify arenas vs on-demand allocation? (Cache rebuilds and attribution queries are leading candidates.)
+- Do we need reference-counted handles for cache snapshots or can we keep push/pull lifetimes simple?
+- How should allocator configuration integrate with future configuration files or environment toggles?
+- Can we share interning tables across processes, or will they remain in-memory only?
+
+Contributors are encouraged to append observations, benchmarks, or experiments to this document as the architecture evolves.

--- a/docs/architecture/hexagonal/Hexagonal_Architecture.md
+++ b/docs/architecture/hexagonal/Hexagonal_Architecture.md
@@ -1,0 +1,99 @@
+<!-- SPDX-License-Identifier: LicenseRef-MIND-UCAL-1.0 -->
+<!-- © 2025 J. Kirby Ross / Neuroglyph Collective -->
+
+---
+title: Hexagonal Architecture Overview
+description: Structure, layering rules, and migration guidance for GitMind's core services.
+audience: [contributors, developers]
+domain: [architecture]
+tags: [hexagonal, architecture, layering]
+status: draft
+last_updated: 2025-10-09
+---
+
+# Hexagonal Architecture Overview
+
+The GitMind core is transitioning to a hexagonal (ports-and-adapters) design so that domain logic remains pure, testable, and independent of infrastructure details. This document captures the target structure and the expectations contributors must follow.
+
+## Table of Contents
+
+- Goals & Principles
+- Layering Model
+- Port Taxonomy
+- Adapter Responsibilities
+- Composition & Context Wiring
+- Migration Guidelines
+- Verification Checklist
+- Open Questions
+
+## 1. Goals & Principles
+
+- **Single Responsibility:** Each translation unit implements one concept (domain entity, port facade, adapter, etc.).
+- **Pure Domain Core:** Domain modules own business rules and should be deterministic, allocation-free, and free of IO.
+- **Dependency Injection:** All side effects flow through ports injected into services via `gm_context_t` (or future context structs).
+- **Test Double Friendly:** Every outbound port must have a fake in `core/tests/fakes/**` so unit tests never touch real infrastructure.
+- **No Hidden State:** Global singletons are being removed; services express their dependencies explicitly in constructor/init helpers.
+
+## 2. Layering Model
+
+We organize code into concentric layers:
+
+| Layer | Location | Responsibilities |
+| --- | --- | --- |
+| **Domain Core** | `core/src/domain/**`, headers under `core/include/gitmind/<domain>/` | Entities, value objects, pure functions, validation logic. Never touch IO or context. |
+| **Application Services** | `core/src/app/**` | Orchestrate use cases, manage transactions, translate inbound intents to domain calls. All dependencies provided via ports. |
+| **Inbound Ports** | `core/include/gitmind/ports/*_command_port.h`, `*_query_port.h`, `*_admin_port.h` | Define entry points for CLI, hooks, or background schedulers. Own request/response contracts and surface `gm_result_*`. |
+| **Outbound Ports** | `core/include/gitmind/ports/**` | Declare dependencies on infrastructure (git repo, filesystem, clock, etc.). Provide helper destroy functions when they allocate. |
+| **Adapters (Runtime)** | `core/src/adapters/<area>/**` | Concrete implementations that talk to libgit2, filesystem, env, logging, telemetry, etc. |
+| **Adapters (Test)** | `core/tests/fakes/**` | Deterministic fakes/stubs implementing outbound ports for unit tests. |
+| **Composition Roots** | `core/src/app/cli_composition.c`, future background composition files | Assemble contexts, wire ports to adapters, register allocators. |
+
+Crossing inward (toward the domain) requires an explicit interface dependency; domain code never imports adapter headers.
+
+## 3. Port Taxonomy
+
+- **Inbound (driving) ports** handle commands and queries. Examples: `gm_cmd_journal_port_vtbl`, `gm_cmd_cache_build_port_vtbl`, `gm_qry_cache_port_vtbl`.
+- **Outbound (driven) ports** encapsulate side effects: git repository, refs, filesystem temp directories, logger, metrics, entropy, clock, process, env.
+- **Future additions** under discussion include an allocator port, metrics budget tracker, and git-object walkers. Design new ports as POD structs containing function pointers plus optional context pointer.
+- Every outbound port must ship with:
+  - Runtime adapter in `core/src/adapters/...`
+  - Fake/deterministic implementation under `core/tests/fakes/...`
+  - Contract tests ensuring behaviour matches documentation.
+
+## 4. Adapter Responsibilities
+
+- Maintain ownership clarity: adapters that allocate memory must document and expose a matching free/destroy helper.
+- Avoid caching mutable global state; prefer adapter instances stored in context structs.
+- Respect logging and telemetry guidelines—return `gm_result_void_t`, never drop errors.
+- Provide granular init/dispose functions (e.g., `gm_posix_fs_temp_port_create`) so composition roots can assemble adapters cleanly.
+
+## 5. Composition & Context Wiring
+
+- `gm_context_t` is the current runtime context. It should remain a thin aggregate of ports, log formatter function pointer, and configuration.
+- Composition roots create concrete adapters, store them in the context, and hand references to application services/inbound ports.
+- Future plans include slicing context per bounded context (cache, journal, attribution) to enforce SRP even further.
+- Avoid on-demand global initialization; prefer explicit `*_init` helpers invoked during context assembly.
+
+## 6. Migration Guidelines
+
+1. **Touch-Point Rule:** If you edit a file that mixes responsibilities, extract the functionality you touched into a dedicated translation unit consistent with hexagonal boundaries.
+2. **Ports First:** When encountering direct IO in application services or domain code, introduce an outbound port before implementing new features.
+3. **No IO in Domain:** When porting legacy modules, split IO into adapters, keep computation in `core/src/domain/**`.
+4. **Tests:** Unit tests should rely exclusively on fakes; integration tests exercise real adapters inside Docker.
+5. **Documentation:** Update `docs/activity/<date>_hexagonal.md` with progress, and note any new ports/adapters in `AGENTS.md` or dedicated architecture docs.
+
+## 7. Verification Checklist
+
+- Does the module obey the layer boundaries (no adapter header includes in domain code)?
+- Are dependencies injected through function parameters or context structs instead of static globals?
+- If the code allocates memory, is ownership explicit and paired with cleanup?
+- Do logs/metrics handle `gm_result_void_t` correctly and free `gm_error_t` on failure?
+- Have fakes/tests been updated to reflect new ports or adapter behavior?
+
+## 8. Open Questions
+
+- How should allocator ports integrate with `gm_context_t` without bloating every service? (See `docs/architecture/Memory_Allocation_Policy.md` for ideas.)
+- What is the best composition strategy for background daemons that share adapters across long-lived tasks?
+- Do we need a code generator or templates for new ports/adapters to avoid boilerplate drift?
+
+Contributors are encouraged to extend this document as the migration advances or when new architectural decisions land.

--- a/docs/telemetry/Telemetry_Strategy.md
+++ b/docs/telemetry/Telemetry_Strategy.md
@@ -1,0 +1,87 @@
+<!-- SPDX-License-Identifier: LicenseRef-MIND-UCAL-1.0 -->
+<!-- © 2025 J. Kirby Ross / Neuroglyph Collective -->
+
+---
+title: Telemetry Strategy
+description: Logging and metrics approach, ownership expectations, and future enhancements.
+audience: [contributors, developers]
+domain: [telemetry]
+tags: [logging, metrics, telemetry]
+status: draft
+last_updated: 2025-10-09
+---
+
+# Telemetry Strategy
+
+This document summarizes how GitMind emits logs and metrics today, the ownership rules around telemetry data, and exploratory ideas for improving observability without compromising memory safety.
+
+## Table of Contents
+
+- Objectives
+- Current Architecture
+- Logging Guidelines
+- Metrics Guidelines
+- Memory & Ownership Rules
+- Testing Expectations
+- Future Ideas
+- Open Questions
+
+## 1. Objectives
+
+- Provide structured, low-noise telemetry that can be consumed by CI, operators, and future dashboards.
+- Keep telemetry orthogonal to domain logic by routing through ports and formatters.
+- Ensure logging/metrics failures never leak `gm_error_t` instances or derail primary workflows beyond returning an error result.
+
+## 2. Current Architecture
+
+- **Ports:**
+  - `gm_logger_port_t` exposes `gm_logger_log` returning `gm_result_void_t`.
+  - `gm_metrics_port_t` exposes `gm_metrics_timing_ms`, `gm_metrics_counter_add`, and related helpers.
+- **Formatter seam:** `gm_log_formatter_fn` converts key/value pairs to text or JSON depending on telemetry config (`gm_telemetry_cfg_t`). The formatter lives in `core/src/telemetry/log_format.c` and defaults to JSON (structured) or plain text.
+- **Telemetry config:** `gm_telemetry_cfg_load` (in `core/src/telemetry/config.c`) reads environment variables to determine formatter, enabled metrics, and extras budget.
+- **Injection:** `gm_context_t` stores the logger port, metrics port, and the active formatter function pointer used by services.
+
+## 3. Logging Guidelines
+
+- Always capture the return value of `gm_logger_log`. If `result.ok` is false, free `result.u.err` immediately unless you propagate it.
+- Prefer structured logs using formatter key/value arrays. Include `event`, `branch`, `mode`, `duration_ms`, etc. Text fallbacks should only be used when the formatter fails or truncates.
+- Log start/end events for long-running operations (journal read/append, cache rebuild) to aid traceability.
+- Treat truncation as an error: if `gm_snprintf` reports truncation while building a fallback message, log an error and continue with an empty message.
+
+## 4. Metrics Guidelines
+
+- Like logging, metrics helpers return `gm_result_void_t`; capture and free errors.
+- Guard metric emission with feature flags from `gm_telemetry_cfg_t` (`metrics_enabled`).
+- Standard metrics:
+  - Duration timers: `*.duration_ms`
+  - Counters: `*.edges_total`, `cache.*`, `journal.*`
+- Tags (`char tags[256]`) should be built via `gm_telemetry_build_tags`. On failure, clear the tag buffer and continue without tags to avoid emitting stale data.
+
+## 5. Memory & Ownership Rules
+
+- Telemetry helpers may allocate temporary buffers (e.g., canonical paths for repo tags). Callers must copy results into stack buffers and free the original to avoid leaks.
+- Error objects (`gm_error_t`) returned from logger/metrics ports are heap allocations. `gm_error_free` must be called unless ownership transfers up the stack via result propagation.
+- Formatter functions receive caller-owned buffers (`msg[256]`) and must not retain pointers after returning.
+
+## 6. Testing Expectations
+
+- Unit tests that exercise telemetry paths should use fakes (`core/tests/fakes/metrics/*`, `core/tests/fakes/logging/*`) to assert that calls occur and no errors leak.
+- Integration tests running inside Docker verify real adapters but still guard against memory leaks by consuming `gm_result_void_t` outcomes.
+- When adding new telemetry, extend tests to validate tag contents and error handling.
+
+## 7. Future Ideas (Non-Commitments)
+
+- **Structured sinks:** One idea might be to add a port for streaming events to JSONL or OpenTelemetry exporters once the CLI integrates with external systems.
+- **Telemetry budgets:** A metrics/diagnostics hybrid port could track per-module warning budgets, allowing CI to enforce “warnings == bugs.”
+- **Allocator integration:** Telemetry adapters could consume a custom allocator port to decouple buffer management from `malloc`.
+- **Sampling/log levels:** Introduce configurable sampling for high-volume events (e.g., cache rebuild progress) to reduce noise.
+- **Correlation IDs:** Provide context-level correlation IDs so logs and metrics from the same request are easily grouped.
+
+## 8. Open Questions
+
+- What format should future machine-consumable telemetry use (JSON, protobuf, OTLP)?
+- How do we balance detailed diagnostic logs with performance in high-frequency operations?
+- Should telemetry failures ever bubble up to callers, or remain best-effort? (Currently best-effort.)
+- How can we expose telemetry configuration safely to users without leaking secrets?
+
+As telemetry evolves, update this document alongside code changes to keep operators and contributors aligned.

--- a/memory-allocation-tasks.md
+++ b/memory-allocation-tasks.md
@@ -1,0 +1,109 @@
+# Memory Allocation Strategy — Execution Checklist
+
+- [ ] Global Toggles & CI Variants
+> [!info]- Implementation Details
+> **Scope:** Introduce runtime kill-switches (`GM_DISABLE_CUSTOM_ALLOCATORS`, tracing toggle) and deterministic CI variants (ASAN/LSAN, release, budgeted runs).  
+> **Steps:** wire env parsing into context bootstrap; update CI configs/docker scripts; pin budget job to a vendored fixture repo snapshot.  
+> **Acceptance:** Dedicated CI matrix green (asan+lsan, release, budgeted fixture); setting `GM_DISABLE_CUSTOM_ALLOCATORS=1` forces legacy system allocator with zero code changes.
+
+- [ ] Allocator Port Scaffolding
+> [!info]- Implementation Details
+> **Scope:** Add `gitmind/ports/allocator_port.h` and `gitmind/util/alloc_wrappers.h` with helpers (`gm_xalloc`, etc.) and diagnostics hooks.  
+> **Steps:** define `gm_allocator_port_t` (function pointers, diagnostics), inline wrappers, umbrella-safe includes.  
+> **Acceptance:** Project builds; no domain/service file includes `<stdlib.h>` for allocation APIs.
+
+- [ ] System Allocator Adapter & Tests
+> [!info]- Implementation Details
+> **Scope:** Default adapter wrapping `malloc`/`realloc`/`free`, storing diagnostics with atomics; place under `core/src/adapters/memory/`.  
+> **Steps:** implement adapter factory; add unit/TSAN smoke tests validating `bytes_outstanding`, `peak`, `failures_total`.  
+> **Acceptance:** Tests confirm counters behave under concurrency; adapter passes TSAN or documents thread safety w/ atomics.
+
+- [ ] Thread Allocator Through gm_context_t
+> [!info]- Implementation Details
+> **Scope:** Make allocator mandatory in `gm_context_t`, composition roots, and test fixtures.  
+> **Steps:** update struct, init helpers, fakes; run `make header-compile`.  
+> **Acceptance:** All builds succeed; null allocator use prevented at compile time.
+
+- [ ] Raw Alloc Guardrails (CI + Pre-commit)
+> [!info]- Implementation Details
+> **Scope:** Script `scripts/check-no-raw-allocs.sh` and register in pre-commit & CI; allowlist allocator implementation files only.  
+> **Steps:** author POSIX shell script, integrate with Meson/Make, document in `AGENTS.md`.  
+> **Acceptance:** Introducing raw `malloc`/`free` outside allowlist fails pre-commit and CI.
+
+- [ ] FS Temp Ports via Allocator & gm_fs_path_free_owned
+> [!info]- Implementation Details
+> **Scope:** Inject allocator into posix/fake temp adapters; canonical paths `_owned`; add shared destroy helper.  
+> **Steps:** adjust adapters, tests, and call sites (journal/cache) to use `gm_fs_path_free_owned`.  
+> **Acceptance:** All canonical paths freed via helper; LSAN/tracing show zero leaks.
+
+- [ ] Arena Utility (Thread-confined, max_align_t)
+> [!info]- Implementation Details
+> **Scope:** Implement `gitmind/util/arena.{h,c}` with geometric growth, cap enforcement, `max_align_t` guarantee, optional `*_alloc_aligned`, and optional zero_on_free behaviour; arenas are per-operation and thread-confined.  
+> **Steps:** use allocator port for backing blocks, enforce `max_align_t` alignment by default, provide aligned variant, expose zeroize toggle for security-sensitive buffers, add unit tests for cap, reset, alignment, and zeroization flag behaviour.  
+> **Acceptance:** Unit tests pass; arena rejects cap overflow; documentation states thread-confined policy.
+
+- [ ] Cache Rebuild Integration with Arena
+> [!info]- Implementation Details
+> **Scope:** Wrap cache rebuild entry in arena begin/end; move temp buffers into arena; ensure nothing escapes scope.  
+> **Steps:** refactor `cache_rebuild_service.c`, audit early returns; add LSAN regression tests.  
+> **Acceptance:** Rebuild behaviour unchanged; LSAN/tracing clean; arena freed on all paths.
+
+- [ ] Allocation Metrics & Deterministic Budget
+> [!info]- Implementation Details
+> **Scope:** Emit `alloc.peak_bytes` with `alloc.op=cache.rebuild`; deterministic budget using vendored fixture tarball + pinned SHA embedded in repo (no network).  
+> **Steps:** measure via tracing allocator, capture allocator ID to guard cross-free attempts, warn ≥80% cap (204 MiB), fail >256 MiB, log fixture SHA/hash and environment metadata.  
+> **Acceptance:** Budget job reports peak and hash; job fails if over cap; telemetry errors freed.
+
+- [ ] Slab Allocator Utility (Per-thread policy)
+> [!info]- Implementation Details
+> **Scope:** `gitmind/util/slab.{h,c}` with bins 32/64/128/256, 64 KiB superblocks, `max_align_t` guarantee plus optional aligned variant; instantiate per-thread via TLS or context injection with documented policy.  
+> **Steps:** implement per-thread slab map (or TLS), ensure cross-thread access is guarded or forbidden, add tests for bin selection, reuse, TSAN safety, and zeroization option.  
+> **Acceptance:** Unit/TSAN tests green; documentation states thread policy; alignment guaranteed.
+
+- [ ] Route Small Objects Through Slab
+> [!info]- Implementation Details
+> **Scope:** Update `gm_error_t`, telemetry kv structs, other ≤256B pods to allocate via slab API.  
+> **Steps:** refactor constructors/destructors; ensure slab frees on destroy; benchmark jitter before/after.  
+> **Acceptance:** Benchmarks show reduced small-alloc jitter; LSAN/tracing remain clean.
+
+- [ ] Intern Table Utility (Service-scoped, refcounted)
+> [!info]- Implementation Details
+> **Scope:** `gitmind/util/intern.{h,c}` offering acquire/retain/release, pointer access, `max_align_t` storage; implement internal sharded locks (or documented single-thread guarantee) for multi-thread safety.  
+> **Steps:** implement hash table with sharded locks, ref counting, tests for churn/dedup and threaded contention.  
+> **Acceptance:** Unit tests cover dedup & retain/release; documented thread model; memory steady after churn.
+
+- [ ] Apply Interning in Hot Services
+> [!info]- Implementation Details
+> **Scope:** Integrate intern tables into journal reader/writer, cache telemetry, other repeated path/OID usage.  
+> **Steps:** replace `strdup/gm_strcpy_safe` loops with intern handles; ensure service lifetime manages table; update metrics/test coverage.  
+> **Acceptance:** Functional parity; instrumentation shows drop in duplicate strings; docs updated.
+
+- [ ] OOM-after-N Allocator Wrapper & Test Harness
+> [!info]- Implementation Details
+> **Scope:** Wrapper around allocator port decrementing counter; env `GM_TEST_OOM_N` for tests.  
+> **Steps:** implement wrapper, add Meson test cases with N∈{1,3,7,37}; ensure deterministic resets.  
+> **Acceptance:** Tests pass under OOM scenarios; no infinite retries; tracing confirms no leaks post-failure.
+
+- [ ] Tracing Allocator Wrapper & Leak Assertions
+> [!info]- Implementation Details
+> **Scope:** Wrapper tracking outstanding bytes, peak, failures; stamps allocator ID (debug) to forbid cross-allocator frees; asserts zero outstanding in teardown; optional zeroization toggle.  
+> **Steps:** implement wrapper with allocator-ID tagging (debug builds), integrate into test fixtures, add optional secure wipe hook and instrumentation toggles.  
+> **Acceptance:** Tests fail fast on non-zero outstanding bytes with informative diagnostics; zeroization optional flag works.
+
+- [ ] Ownership Suffix Doc-lint (Public Headers Only)
+> [!info]- Implementation Details
+> **Scope:** Script ensuring `_owned` exports have destroy helper, `_view`/`_borrowed` documented; ignore static/private symbols.  
+> **Steps:** parse headers, enforce doc presence, integrate with CI; allowlist legacy items with TODO+issue.  
+> **Acceptance:** Missing destroy/doc fails CI immediately; script skips non-public symbols.
+
+- [ ] Allocation Histogram Instrumentation (Test-only)
+> [!info]- Implementation Details
+> **Scope:** Optional histogram sampling controlled by `GM_ALLOC_HISTO` to log p50/p90/p99 during tests.  
+> **Steps:** implement lightweight sampler in tracing allocator; ensure disabled in release builds.  
+> **Acceptance:** When enabled, tests print percentiles & env metadata; disabled by default to avoid perf hit.
+
+- [ ] Documentation & Release Notes
+> [!info]- Implementation Details
+> **Scope:** Update Memory Allocation Policy, Hexagonal Architecture doc, Telemetry Strategy, `AGENTS.md`; add release notes & benchmark tables with env hashes.  
+> **Steps:** describe allocator port usage, thread policy, kill-switch, CI budgets; record benchmark methodology.  
+> **Acceptance:** `make docs-verify` passes; release notes include rollback plan and fixture/hash references.


### PR DESCRIPTION
## Summary
- add memory allocation policy doc plus hexagonal and telemetry overviews
- capture allocator execution checklist in memory-allocation-tasks.md
- refresh AGENTS references to keep docs guardrails aligned

## Testing
- make docs-verify

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Selectable repository tag hashing (fnv default, sha256 option).
  * Structured logging for cache rebuild and journal read/write with formatter fallback.
  * Hardened telemetry configuration and tagging behavior.

* Bug Fixes
  * Safer path canonicalization and memory ownership to prevent leaks/crashes.
  * Truncation now treated as fatal; improved error handling in logging/metrics.

* Documentation
  * New guides: Memory Allocation Strategy/Policy, Hexagonal Architecture, Telemetry Strategy.
  * Updated telemetry config and repo-hash flag docs.

* Tests
  * Reorganized integration suite; added adapter and journal/cache tests; improved fakes.

* Chores
  * Removed legacy auto review-seeding workflow; CI-local run verified green.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->